### PR TITLE
trimmed the fields before validating

### DIFF
--- a/lib/src/min_length.dart
+++ b/lib/src/min_length.dart
@@ -11,6 +11,6 @@ class MinLength extends ValidationType {
     if (inputValue == null && length <= 0) {
       return true;
     }
-    return inputValue == null ? false : inputValue.length >= length;
+    return inputValue == null ? false : inputValue.trim().length >= length;
   }
 }

--- a/lib/src/required.dart
+++ b/lib/src/required.dart
@@ -6,6 +6,6 @@ class Required extends ValidationType {
 
   @override
   bool isValid(String? inputValue) {
-    return inputValue != null && inputValue.isNotEmpty;
+    return inputValue != null && inputValue.trim().isNotEmpty;
   }
 }

--- a/test/simple_form_validator_test.dart
+++ b/test/simple_form_validator_test.dart
@@ -17,6 +17,10 @@ void main() {
     test('calling validate with a value will return null', () {
       expect(null, Validator.validate("Valid input", [Required(errorText)]));
     });
+
+    test('calling validate with a value with only spaces', () {
+      expect(errorText, Validator.validate("  ", [Required(errorText)]));
+    });
   });
 
   group('MinLength test', () {
@@ -27,6 +31,11 @@ void main() {
         () {
       expect(errorText, Validator.validate("", [MinLength(1, errorText)]));
     });
+    test(
+        'calling validate with an value with only space while minimal length is 1 will return $errorText',
+        () {
+      expect(errorText, Validator.validate(" ", [MinLength(1, errorText)]));
+    });
 
     test(
         'calling validate with a null value while minimal length is 2 will return $errorText}',
@@ -34,6 +43,11 @@ void main() {
       expect(errorText, Validator.validate(null, [MinLength(2, errorText)]));
     });
 
+    test(
+        'calling validate with a value with only spaces, greater than minimal length will return $errorText',
+        () {
+      expect(errorText, Validator.validate("  ", [MinLength(2, errorText)]));
+    });
     test(
         'calling validate with a null value while minimal length is 0 will return null',
         () {
@@ -44,6 +58,11 @@ void main() {
         'calling validate with some value that matches minimal length will return null',
         () {
       expect(null, Validator.validate("ma", [MinLength(2, errorText)]));
+    });
+    test(
+        'calling validate with some value with trailing space that matches minimal length will return $errorText',
+        () {
+      expect(errorText, Validator.validate("m ", [MinLength(2, errorText)]));
     });
 
     test(
@@ -90,6 +109,12 @@ void main() {
         'calling validate with a value that is greater than maximum length will return $errorText',
         () {
       expect(errorText, Validator.validate("mat", [MaxLength(2, errorText)]));
+    });
+
+    test(
+        'calling validate with an value with only space while minimal length is 1 will return $errorText',
+        () {
+      expect(errorText, Validator.validate(" ", [MinLength(1, errorText)]));
     });
   });
 


### PR DESCRIPTION
This will fix the issue in a case when a user enters only spaces but the required validator returns true and in case of minlength valdiator user can enter spaces to bypass that.

To fix this issue I used the string's trim() method to trim the leading & trailing spaces.